### PR TITLE
Disable manual builds

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,8 +2,10 @@ name: Deploy Sphinx to GitHub Pages
 
 on:
   push:
-    branches: 
+    branches:
       - '*'
+    paths:
+      - 'website/source/**'
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: 
       - '*'
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
Deploy to GH pages should be done automatically and not triggered manually.