### PR TITLE
Fix error with installation make2graph

### DIFF
--- a/website/source/tutorials/makefiles/content/003_dependency_create_graph/index.rst
+++ b/website/source/tutorials/makefiles/content/003_dependency_create_graph/index.rst
@@ -82,7 +82,7 @@ Also one can install ``make2graph`` and ``graphviz`` by using following command:
 
       .. code-block:: bash
 
-         sudo apt-get install make2graph graphviz
+         sudo apt-get install makefile2graph graphviz
 
 Create graph
 ++++++++++++


### PR DESCRIPTION
Looks like there were wrong name of package for make2graph.  Fixed this.